### PR TITLE
Add gray variant

### DIFF
--- a/astrolabe-ui/Button.tsx
+++ b/astrolabe-ui/Button.tsx
@@ -18,6 +18,7 @@ export const buttonVariants = cva(
 				danger: "bg-danger-500 text-danger-50 hover:bg-danger-600",
 				outline: "border border-current",
 				ghost: "hover:bg-primary-300 hover:text-primary-950",
+				gray: "text-secondary-500 hover:bg-primary-100 bg-surface-100 aria-disabled:cursor-not-allowed aria-disabled:text-gray-600",
 				link: "underline-offset-4 hover:underline text-white",
 				hyperlink:
 					"text-blue-800 underline-offset-4 underline hover:underline-offset-8 transition-all hover:text-blue-700",

--- a/astrolabe-ui/CircularProgress.tsx
+++ b/astrolabe-ui/CircularProgress.tsx
@@ -1,5 +1,6 @@
-import clsx from "clsx";
 import { cva, VariantProps } from "class-variance-authority";
+import { cn } from "@astrolabe/client/util/utils";
+import { HTMLAttributes } from "react";
 
 const circularProgressVariants = cva("stroke-current", {
 	variants: {
@@ -24,15 +25,26 @@ const circularProgressVariants = cva("stroke-current", {
 
 export function CircularProgress({
 	className,
+	variant,
+	size,
+	alignment, // make sure that you extract any variants added so the spread operator doesn't pass it to the svg
 	...props
-}: {
+}: HTMLAttributes<SVGSVGElement> & {
 	className?: string;
 } & VariantProps<typeof circularProgressVariants>) {
 	return (
 		<svg
-			className={clsx(className, circularProgressVariants(props))}
+			className={cn(
+				circularProgressVariants({
+					variant,
+					size,
+					alignment,
+				}),
+				className
+			)}
 			viewBox="0 0 24 24"
 			xmlns="http://www.w3.org/2000/svg"
+			{...props}
 		>
 			<path d="M10.14,1.16a11,11,0,0,0-9,8.92A1.59,1.59,0,0,0,2.46,12,1.52,1.52,0,0,0,4.11,10.7a8,8,0,0,1,6.66-6.61A1.42,1.42,0,0,0,12,2.69h0A1.57,1.57,0,0,0,10.14,1.16Z">
 				<animateTransform


### PR DESCRIPTION
spelling  it "gray" because tailwind uses it, honest.

* Adds "gray" button variant for RUI map
* Spreads props of circular progress and adds HTML props.