### PR TITLE
Split change password endpoint into two for authenticated/unauthentic…

### DIFF
--- a/Astrolabe.LocalUsers/AbstractLocalUserController.cs
+++ b/Astrolabe.LocalUsers/AbstractLocalUserController.cs
@@ -3,8 +3,8 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Astrolabe.LocalUsers;
 
-public abstract class AbstractLocalUserController<TNewUser, TUserId> : ControllerBase 
-    where TNewUser : ICreateNewUser 
+public abstract class AbstractLocalUserController<TNewUser, TUserId> : ControllerBase
+    where TNewUser : ICreateNewUser
 {
     private readonly ILocalUserService<TNewUser, TUserId> _localUserService;
 
@@ -12,7 +12,7 @@ public abstract class AbstractLocalUserController<TNewUser, TUserId> : Controlle
     {
         _localUserService = localUserService;
     }
-    
+
     [HttpPost("create")]
     public Task CreateAccount([FromBody] TNewUser newUser)
     {
@@ -24,7 +24,7 @@ public abstract class AbstractLocalUserController<TNewUser, TUserId> : Controlle
     {
         return _localUserService.VerifyAccount(code);
     }
-    
+
     [HttpPost("mfaVerify")]
     public Task<string> MfaVerifyAccount([FromBody] MfaAuthenticateRequest mfaVerifyAccountRequest)
     {
@@ -36,8 +36,7 @@ public abstract class AbstractLocalUserController<TNewUser, TUserId> : Controlle
     {
         return _localUserService.Authenticate(authenticateRequest);
     }
-    
-    
+
     [HttpPost("mfaCode/authenticate")]
     public async Task SendMfaCode([FromBody] MfaCodeRequest mfaCodeRequest)
     {
@@ -45,7 +44,9 @@ public abstract class AbstractLocalUserController<TNewUser, TUserId> : Controlle
     }
 
     [HttpPost("mfaAuthenticate")]
-    public async Task<string> MfaAuthenticate([FromBody] MfaAuthenticateRequest mfaAuthenticateRequest)
+    public async Task<string> MfaAuthenticate(
+        [FromBody] MfaAuthenticateRequest mfaAuthenticateRequest
+    )
     {
         return await _localUserService.MfaAuthenticate(mfaAuthenticateRequest);
     }
@@ -61,33 +62,37 @@ public abstract class AbstractLocalUserController<TNewUser, TUserId> : Controlle
     {
         return _localUserService.ChangeEmail(email, GetUserId);
     }
-    
+
     [HttpPost("changeMfaNumber")]
     public Task ChangeMfaNumber(ChangeMfaNumber number)
     {
         return _localUserService.ChangeMfaNumber(number, GetUserId);
     }
-    
+
     [HttpPost("mfaChangeMfaNumber")]
     public Task MfaChangeMfaNumber(MfaChangeNumber change)
     {
         return _localUserService.MfaChangeMfaNumber(change, GetUserId);
     }
-    
+
     [Authorize]
-    [AllowAnonymous]
     [HttpPost("changePassword")]
-    public Task<string> ChangePassword([FromBody] ChangePassword change, [FromQuery] string? resetCode)
+    public Task<string> ChangePassword([FromBody] ChangePassword change)
     {
-        return _localUserService.ChangePassword(change, resetCode, GetUserId);
+        return _localUserService.ChangePassword(change, GetUserId);
     }
-    
+
+    [HttpPost("resetPassword")]
+    public Task ResetPassword([FromBody] ResetPassword reset, [FromQuery] string resetCode)
+    {
+        return _localUserService.ResetPassword(reset, resetCode);
+    }
+
     [HttpPost("mfaCode/number")]
     public async Task SendMfaCode(string number)
     {
-        await _localUserService.SendMfaCode(number,  GetUserId);
+        await _localUserService.SendMfaCode(number, GetUserId);
     }
-    
 
     protected abstract TUserId GetUserId();
 }

--- a/Astrolabe.LocalUsers/AbstractLocalUserService.cs
+++ b/Astrolabe.LocalUsers/AbstractLocalUserService.cs
@@ -3,17 +3,22 @@ using FluentValidation;
 
 namespace Astrolabe.LocalUsers;
 
-public abstract class AbstractLocalUserService<TNewUser, TUserId> : ILocalUserService<TNewUser, TUserId> where TNewUser : ICreateNewUser
+public abstract class AbstractLocalUserService<TNewUser, TUserId>
+    : ILocalUserService<TNewUser, TUserId>
+    where TNewUser : ICreateNewUser
 {
     private readonly IPasswordHasher _passwordHasher;
     private readonly LocalUserMessages _localUserMessages;
 
-    protected AbstractLocalUserService(IPasswordHasher passwordHasher, LocalUserMessages? localUserMessages)
+    protected AbstractLocalUserService(
+        IPasswordHasher passwordHasher,
+        LocalUserMessages? localUserMessages
+    )
     {
         _passwordHasher = passwordHasher;
         _localUserMessages = localUserMessages ?? new LocalUserMessages();
     }
-    
+
     public async Task CreateAccount(TNewUser newUser)
     {
         var existingAccounts = await CountExisting(newUser);
@@ -28,8 +33,12 @@ public abstract class AbstractLocalUserService<TNewUser, TUserId> : ILocalUserSe
 
     protected abstract Task SendVerificationEmail(TNewUser newUser, string verificationCode);
 
-    protected abstract Task CreateUnverifiedAccount(TNewUser newUser, string hashedPassword, string verificationCode);
-    
+    protected abstract Task CreateUnverifiedAccount(
+        TNewUser newUser,
+        string hashedPassword,
+        string verificationCode
+    );
+
     protected virtual string CreateEmailCode()
     {
         return Guid.NewGuid().ToString();
@@ -40,22 +49,32 @@ public abstract class AbstractLocalUserService<TNewUser, TUserId> : ILocalUserSe
         return Task.CompletedTask;
     }
 
-    protected virtual Task ApplyChangeEmailRules(ChangeEmail user, AbstractValidator<ChangeEmail> validator)
+    protected virtual Task ApplyChangeEmailRules(
+        ChangeEmail user,
+        AbstractValidator<ChangeEmail> validator
+    )
     {
         return Task.CompletedTask;
     }
 
-    protected virtual void ApplyPasswordRules<T>(AbstractValidator<T> validator) where T : IPasswordHolder
+    protected virtual void ApplyPasswordRules<T>(AbstractValidator<T> validator)
+        where T : IPasswordHolder
     {
         validator.RuleFor(x => x.Password).MinimumLength(8);
     }
-    
-    protected virtual Task ApplyChangeNumberRules(ChangeMfaNumber change, AbstractValidator<ChangeMfaNumber> validator)
+
+    protected virtual Task ApplyChangeNumberRules(
+        ChangeMfaNumber change,
+        AbstractValidator<ChangeMfaNumber> validator
+    )
     {
         return Task.CompletedTask;
     }
-    
-    protected virtual Task ApplyMfaCodeRules(MfaCodeRequest request, AbstractValidator<MfaCodeRequest> validator)
+
+    protected virtual Task ApplyMfaCodeRules(
+        MfaCodeRequest request,
+        AbstractValidator<MfaCodeRequest> validator
+    )
     {
         return Task.CompletedTask;
     }
@@ -64,13 +83,14 @@ public abstract class AbstractLocalUserService<TNewUser, TUserId> : ILocalUserSe
     {
         return CountExistingForEmail(newUser.Email);
     }
-    
+
     protected abstract Task<int> CountExistingForEmail(string email);
-    
+
     public async Task<string> VerifyAccount(string code)
     {
         var token = await VerifyAccountCode(code);
-        if (token == null) throw new UnauthorizedException();
+        if (token == null)
+            throw new UnauthorizedException();
         return token;
     }
 
@@ -80,52 +100,62 @@ public abstract class AbstractLocalUserService<TNewUser, TUserId> : ILocalUserSe
     {
         var hashed = _passwordHasher.Hash(authenticateRequest.Password);
         var token = await AuthenticatedHashed(authenticateRequest, hashed);
-        if (token == null) throw new UnauthorizedException();
+        if (token == null)
+            throw new UnauthorizedException();
         return token;
     }
 
     public async Task<string> MfaVerifyAccount(MfaAuthenticateRequest mfaAuthenticateRequest)
     {
-
         var token = await MfaVerifyAccountForUserId(mfaAuthenticateRequest);
-        if (token == null) throw new UnauthorizedException();
+        if (token == null)
+            throw new UnauthorizedException();
         return token;
     }
 
-    protected abstract Task<string?> MfaVerifyAccountForUserId(MfaAuthenticateRequest mfaAuthenticateRequest);
+    protected abstract Task<string?> MfaVerifyAccountForUserId(
+        MfaAuthenticateRequest mfaAuthenticateRequest
+    );
 
-    protected abstract Task<string?> AuthenticatedHashed(AuthenticateRequest authenticateRequest, string hashedPassword);
+    protected abstract Task<string?> AuthenticatedHashed(
+        AuthenticateRequest authenticateRequest,
+        string hashedPassword
+    );
 
     public async Task ForgotPassword(string email)
     {
         var resetCode = CreateEmailCode();
         await SetResetCodeAndEmail(email, resetCode);
     }
-    
+
     public async Task SendMfaCode(MfaCodeRequest mfaCodeRequest)
     {
         var validator = new MfaCodeValidator();
         await ApplyMfaCodeRules(mfaCodeRequest, validator);
         await validator.ValidateAndThrowAsync(mfaCodeRequest);
-        
-        if(!await SendCode(mfaCodeRequest)) 
+
+        if (!await SendCode(mfaCodeRequest))
             throw new UnauthorizedException();
     }
 
     protected abstract Task<bool> SendCode(MfaCodeRequest mfaCodeRequest);
 
-    protected abstract Task<bool> SendCode(TUserId userId, string? number=null);
-    
+    protected abstract Task<bool> SendCode(TUserId userId, string? number = null);
 
     public async Task<string> MfaAuthenticate(MfaAuthenticateRequest mfaAuthenticateRequest)
     {
-        var token = await VerifyMfaCode(mfaAuthenticateRequest.Token, mfaAuthenticateRequest.Code, mfaAuthenticateRequest.Number);
-        if (token == null) throw new UnauthorizedException();
+        var token = await VerifyMfaCode(
+            mfaAuthenticateRequest.Token,
+            mfaAuthenticateRequest.Code,
+            mfaAuthenticateRequest.Number
+        );
+        if (token == null)
+            throw new UnauthorizedException();
         return token;
     }
 
     protected abstract Task<string?> VerifyMfaCode(string token, string code, string? number);
-    
+
     protected abstract Task<bool> VerifyMfaCode(TUserId userId, string code, string? number);
     protected abstract Task SetResetCodeAndEmail(string email, string resetCode);
 
@@ -139,33 +169,32 @@ public abstract class AbstractLocalUserService<TNewUser, TUserId> : ILocalUserSe
         if (!await EmailChangeForUserId(userId(), hashedPassword, change.NewEmail))
             throw new UnauthorizedException();
     }
-    
-    protected abstract Task<bool> EmailChangeForUserId(TUserId userId, string hashedPassword, string newEmail);
 
-    public async Task<string> ChangePassword(ChangePassword change, string? resetCode, Func<TUserId> userId)
+    protected abstract Task<bool> EmailChangeForUserId(
+        TUserId userId,
+        string hashedPassword,
+        string newEmail
+    );
+
+    public async Task<string> ChangePassword(ChangePassword change, Func<TUserId> userId)
     {
-        (bool, Func<string, Task<string>>?) apply; 
-        if (!string.IsNullOrWhiteSpace(resetCode))
-        {
-            apply = (true, await PasswordChangeForResetCode(resetCode));
-        }
-        else
-        {
-            apply = await PasswordChangeForUserId(userId(), _passwordHasher.Hash(change.OldPassword));
-        }
-        var (passwordOk, applyChange) = apply;
+        var (passwordOk, applyChange) = await PasswordChangeForUserId(
+            userId(),
+            _passwordHasher.Hash(change.OldPassword)
+        );
         if (applyChange == null)
             throw new NotFoundException();
-        
+
         var validator = new ChangePasswordValidator(passwordOk, _localUserMessages);
         ApplyPasswordRules(validator);
         await validator.ValidateAndThrowAsync(change);
         return await applyChange(_passwordHasher.Hash(change.Password));
-   }
+    }
 
-    protected abstract Task<(bool, Func<string, Task<string>>?)> PasswordChangeForUserId(TUserId userId, string hashedPassword);
-
-    protected abstract Task<Func<string, Task<string>>?> PasswordChangeForResetCode(string resetCode);
+    protected abstract Task<(bool, Func<string, Task<string>>?)> PasswordChangeForUserId(
+        TUserId userId,
+        string oldHashedPassword
+    );
 
     public async Task ChangeMfaNumber(ChangeMfaNumber change, Func<TUserId> userId)
     {
@@ -176,11 +205,15 @@ public abstract class AbstractLocalUserService<TNewUser, TUserId> : ILocalUserSe
         if (!await ChangeMfaNumberForUserId(userId(), hashedPassword, change.NewNumber))
             throw new UnauthorizedException();
     }
-    protected abstract Task<bool> ChangeMfaNumberForUserId(TUserId userId, string hashedPassword, string newNumber);
+
+    protected abstract Task<bool> ChangeMfaNumberForUserId(
+        TUserId userId,
+        string hashedPassword,
+        string newNumber
+    );
 
     public async Task MfaChangeMfaNumber(MfaChangeNumber change, Func<TUserId> userId)
     {
-
         if (!await VerifyMfaCode(userId(), change.Code, change.Number))
             throw new UnauthorizedException();
     }
@@ -188,5 +221,19 @@ public abstract class AbstractLocalUserService<TNewUser, TUserId> : ILocalUserSe
     public async Task SendMfaCode(string number, Func<TUserId> userId)
     {
         await SendCode(userId(), number);
+    }
+
+    protected abstract Task<Func<string, Task>?> PasswordResetForResetCode(string resetCode);
+
+    public async Task ResetPassword(ResetPassword reset, string resetCode)
+    {
+        var applyChange = await PasswordResetForResetCode(resetCode);
+        if (applyChange == null)
+            throw new NotFoundException();
+
+        var validator = new ResetPasswordValidator(_localUserMessages);
+        ApplyPasswordRules(validator);
+        await validator.ValidateAndThrowAsync(reset);
+        await applyChange(_passwordHasher.Hash(reset.Password));
     }
 }

--- a/Astrolabe.LocalUsers/Astrolabe.LocalUsers.csproj
+++ b/Astrolabe.LocalUsers/Astrolabe.LocalUsers.csproj
@@ -1,33 +1,29 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
-    <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <OutputType>Library</OutputType>
-        <IsPackable>true</IsPackable>
-
-        <Version>3.0.0</Version>
-        <Authors>doolse</Authors>
-        <RepositoryUrl>https://github.com/astrolabe-apps/astrolabe-common</RepositoryUrl>
-        <Description>Abstractions / base classes useful for implement local user management, 
-            account creation including email verification, password authentication, password reset.</Description>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
-        <PackageTags>local user management</PackageTags>
-        <Copyright>Copyright ©2024 Astrolabe Enterprises</Copyright>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        
-    </PropertyGroup>
-
-    <ItemGroup>
-      <PackageReference Include="FluentValidation" Version="11.8.0" />
-      <PackageReference Include="Astrolabe.Common" Version="1.1.0" />
-    </ItemGroup>
-    
-    <ItemGroup>
-      <None Update="README.md">
-        <Pack>true</Pack>
-        <PackagePath>/</PackagePath>
-      </None>
-    </ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Library</OutputType>
+    <IsPackable>true</IsPackable>
+    <Version>3.0.0</Version>
+    <Authors>doolse</Authors>
+    <RepositoryUrl>https://github.com/astrolabe-apps/astrolabe-common</RepositoryUrl>
+    <Description>Abstractions / base classes useful for implementing local user management,
+            account creation including email verification, password authentication, password reset.
+        </Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>local user management</PackageTags>
+    <Copyright>Copyright ©2025 Astrolabe Enterprises</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="11.8.0" />
+    <PackageReference Include="Astrolabe.Common" Version="1.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="README.md">
+      <Pack>true</Pack>
+      <PackagePath>/</PackagePath>
+    </None>
+  </ItemGroup>
 </Project>

--- a/Astrolabe.LocalUsers/AuthenticateRequest.cs
+++ b/Astrolabe.LocalUsers/AuthenticateRequest.cs
@@ -1,0 +1,3 @@
+namespace Astrolabe.LocalUsers;
+
+public record AuthenticateRequest(string Username, string Password, bool RememberMe);

--- a/Astrolabe.LocalUsers/ChangePassword.cs
+++ b/Astrolabe.LocalUsers/ChangePassword.cs
@@ -1,9 +1,3 @@
 namespace Astrolabe.LocalUsers;
 
 public record ChangePassword(string OldPassword, string Password, string Confirm) : IPasswordHolder;
-
-public record AuthenticateRequest(string Username, string Password, bool RememberMe);
-
-public record MfaCodeRequest(string Token, bool UpdateNumber, string? Number);
-
-public record MfaAuthenticateRequest(string Token, string Code, string? Number);

--- a/Astrolabe.LocalUsers/ILocalUserService.cs
+++ b/Astrolabe.LocalUsers/ILocalUserService.cs
@@ -1,6 +1,7 @@
 namespace Astrolabe.LocalUsers;
 
-public interface ILocalUserService<TNewUser, TUserId> where TNewUser : ICreateNewUser
+public interface ILocalUserService<TNewUser, TUserId>
+    where TNewUser : ICreateNewUser
 {
     Task CreateAccount(TNewUser newUser);
     Task<string> VerifyAccount(string code);
@@ -10,7 +11,8 @@ public interface ILocalUserService<TNewUser, TUserId> where TNewUser : ICreateNe
     Task SendMfaCode(string number, Func<TUserId> userId);
     Task<string> MfaAuthenticate(MfaAuthenticateRequest mfaAuthenticateRequest);
     Task ForgotPassword(string email);
-    Task<string> ChangePassword(ChangePassword change, string? resetCode, Func<TUserId> userId);
+    Task ResetPassword(ResetPassword reset, string resetCode);
+    Task<string> ChangePassword(ChangePassword change, Func<TUserId> userId);
     Task ChangeEmail(ChangeEmail change, Func<TUserId> userId);
     Task ChangeMfaNumber(ChangeMfaNumber change, Func<TUserId> userId);
     Task MfaChangeMfaNumber(MfaChangeNumber change, Func<TUserId> userId);

--- a/Astrolabe.LocalUsers/MfaAuthenticateRequest.cs
+++ b/Astrolabe.LocalUsers/MfaAuthenticateRequest.cs
@@ -1,0 +1,3 @@
+namespace Astrolabe.LocalUsers;
+
+public record MfaAuthenticateRequest(string Token, string Code, string? Number);

--- a/Astrolabe.LocalUsers/MfaCodeRequest.cs
+++ b/Astrolabe.LocalUsers/MfaCodeRequest.cs
@@ -1,0 +1,3 @@
+namespace Astrolabe.LocalUsers;
+
+public record MfaCodeRequest(string Token, bool UpdateNumber, string? Number);

--- a/Astrolabe.LocalUsers/README.md
+++ b/Astrolabe.LocalUsers/README.md
@@ -221,7 +221,8 @@ The controller provides these standard endpoints:
 - `POST /changeEmail` - Change email address
 - `POST /changeMfaNumber` - Change MFA phone number
 - `POST /mfaChangeMfaNumber` - Change MFA number with verification
-- `POST /changePassword` - Change password (authenticated or with reset code)
+- `POST /changePassword` - Change password (authenticated)
+- `POST /resetPassword` - Reset password (with reset code)
 - `POST /mfaCode/number` - Send MFA code to a specific number
 
 ## License

--- a/Astrolabe.LocalUsers/ResetPassword.cs
+++ b/Astrolabe.LocalUsers/ResetPassword.cs
@@ -1,0 +1,3 @@
+namespace Astrolabe.LocalUsers;
+
+public record ResetPassword(string Password, string Confirm) : IPasswordHolder;

--- a/Astrolabe.LocalUsers/ResetPasswordValidator.cs
+++ b/Astrolabe.LocalUsers/ResetPasswordValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+
+namespace Astrolabe.LocalUsers;
+
+public class ResetPasswordValidator : AbstractValidator<ResetPassword>
+{
+    public ResetPasswordValidator(LocalUserMessages messages)
+    {
+        RuleFor(x => x.Password).NotEmpty();
+        RuleFor(x => x.Confirm)
+            .Must((nu, c) => nu.Password == c)
+            .WithMessage(messages.PasswordMismatch);
+    }
+}

--- a/astrolabe-ui/src/user/ChangeEmailForm.tsx
+++ b/astrolabe-ui/src/user/ChangeEmailForm.tsx
@@ -5,15 +5,17 @@ import { ChangeEmailFormData } from "@astroapps/client";
 import { CircularProgress } from "../CircularProgress";
 import { UserFormContainer } from "./UserFormContainer";
 
+type ChangeEmailFormProps = {
+  className?: string;
+  control: Control<ChangeEmailFormData>;
+  changeEmail: () => Promise<boolean>;
+};
+
 export function ChangeEmailForm({
   className,
   control,
   changeEmail,
-}: {
-  className?: string;
-  control: Control<ChangeEmailFormData>;
-  changeEmail: () => Promise<boolean>;
-}) {
+}: ChangeEmailFormProps) {
   const {
     fields: { password, newEmail },
     disabled,

--- a/astrolabe-ui/src/user/ChangeNumberForm.tsx
+++ b/astrolabe-ui/src/user/ChangeNumberForm.tsx
@@ -1,14 +1,17 @@
-import {
-  Control,
-  useComputed,
-  useControl,
-  useControlEffect,
-} from "@react-typed-forms/core";
+import { Control, useControl, useControlEffect } from "@react-typed-forms/core";
 import { ChangeMfaNumberFormData, useAuthPageSetup } from "@astroapps/client";
 import { UserFormContainer } from "./UserFormContainer";
 import { Textfield } from "../Textfield";
 import { Button } from "../Button";
 import React from "react";
+
+type ChangeNumberFormProps = {
+  className?: string;
+  control: Control<ChangeMfaNumberFormData>;
+  authenticate: () => Promise<boolean>;
+  send: () => Promise<boolean>;
+  runChange: () => Promise<boolean>;
+};
 
 export function ChangeNumberForm({
   className,
@@ -16,13 +19,7 @@ export function ChangeNumberForm({
   authenticate,
   send,
   runChange,
-}: {
-  className?: string;
-  control: Control<ChangeMfaNumberFormData>;
-  authenticate: () => Promise<boolean>;
-  send: () => Promise<boolean>;
-  runChange: () => Promise<boolean>;
-}) {
+}: ChangeNumberFormProps) {
   const {
     fields: { password, newNumber, code },
     error,

--- a/astrolabe-ui/src/user/ChangePasswordForm.tsx
+++ b/astrolabe-ui/src/user/ChangePasswordForm.tsx
@@ -5,22 +5,24 @@ import { ChangePasswordFormData } from "@astroapps/client";
 import { CircularProgress } from "../CircularProgress";
 import { UserFormContainer } from "./UserFormContainer";
 
+type ChangePasswordFormProps = {
+  className?: string;
+  control: Control<ChangePasswordFormData>;
+  changePassword: () => Promise<boolean>;
+};
+
 export function ChangePasswordForm({
   className,
   control,
   changePassword,
-  confirmPrevious,
-}: {
-  className?: string;
-  confirmPrevious?: boolean;
-  control: Control<ChangePasswordFormData>;
-  changePassword: () => Promise<boolean>;
-}) {
+}: ChangePasswordFormProps) {
   const {
     fields: { password, confirm, oldPassword },
     disabled,
   } = control;
+
   const passwordChanged = useControl(false);
+
   return (
     <UserFormContainer className={className}>
       {passwordChanged.value ? (
@@ -40,35 +42,41 @@ export function ChangePasswordForm({
               doChange();
             }}
           >
-            {confirmPrevious && (
-              <Textfield
-                control={oldPassword}
-                label="Old Password"
-                type="password"
-                autoComplete="current-password"
-              />
-            )}
-            <Textfield
-              control={password}
-              label="New Password"
-              type="password"
-              autoComplete="new-password"
-            />
-            <Textfield
-              control={confirm}
-              label="Confirm Password"
-              type="password"
-              autoComplete="new-password"
-            />
-            {disabled && <CircularProgress />}
-            <Button className="w-full" type="submit" disabled={disabled}>
-              Change password
-            </Button>
+            <ChangePassword />
           </form>
         </>
       )}
     </UserFormContainer>
   );
+
+  function ChangePassword() {
+    return (
+      <>
+        <Textfield
+          control={oldPassword}
+          label="Old Password"
+          type="password"
+          autoComplete="current-password"
+        />
+        <Textfield
+          control={password}
+          label="New Password"
+          type="password"
+          autoComplete="new-password"
+        />
+        <Textfield
+          control={confirm}
+          label="Confirm Password"
+          type="password"
+          autoComplete="new-password"
+        />
+        {disabled && <CircularProgress />}
+        <Button className="w-full" type="submit" disabled={disabled}>
+          Change password
+        </Button>
+      </>
+    );
+  }
 
   async function doChange() {
     passwordChanged.value = await changePassword();

--- a/astrolabe-ui/src/user/ForgotPasswordForm.tsx
+++ b/astrolabe-ui/src/user/ForgotPasswordForm.tsx
@@ -1,0 +1,66 @@
+import { Control, useControl } from "@react-typed-forms/core";
+import { Textfield } from "../Textfield";
+import { Button } from "../Button";
+import { ForgotPasswordFormData } from "@astroapps/client";
+import { CircularProgress } from "../CircularProgress";
+import { UserFormContainer } from "./UserFormContainer";
+
+type ForgotPasswordFormProps = {
+  className?: string;
+  control: Control<ForgotPasswordFormData>;
+  requestResetPassword: () => Promise<boolean>;
+};
+
+export function ForgotPasswordForm({
+  className,
+  control,
+  requestResetPassword,
+}: ForgotPasswordFormProps) {
+  const {
+    fields: { email },
+    disabled,
+  } = control;
+  const resetRequested = useControl(false);
+
+  return (
+    <UserFormContainer className={className}>
+      {resetRequested.value ? (
+        <>
+          <h2>Check email to continue</h2>
+          <p className="font-light text-gray-500 dark:text-gray-400">
+            You will receive an email with further instructions on how to reset
+            your password
+          </p>
+        </>
+      ) : (
+        <>
+          <h2>Forgot your password?</h2>
+          <p className="font-light text-gray-500 dark:text-gray-400">
+            Don't fret! Just type in your email and we will send you a link to
+            reset your password!
+          </p>
+          <form
+            className="space-y-4 md:space-y-6"
+            onSubmit={(e) => {
+              e.preventDefault();
+              doRequestReset();
+            }}
+          >
+            <Textfield control={email} label="Email" autoComplete="username" />
+            {disabled && <CircularProgress />}
+            <Button className="w-full" type="submit" disabled={disabled}>
+              Reset Password
+            </Button>
+          </form>
+        </>
+      )}
+    </UserFormContainer>
+  );
+
+  async function doRequestReset() {
+    control.disabled = true;
+    const wasReset = await requestResetPassword();
+    resetRequested.value = wasReset;
+    if (!wasReset) control.disabled = false;
+  }
+}

--- a/astrolabe-ui/src/user/LoginForm.tsx
+++ b/astrolabe-ui/src/user/LoginForm.tsx
@@ -6,17 +6,19 @@ import { LoginFormData, useAuthPageSetup } from "@astroapps/client";
 import { CircularProgress } from "../CircularProgress";
 import { UserFormContainer } from "./UserFormContainer";
 
+type LoginFormProps = {
+  className?: string;
+  control: Control<LoginFormData>;
+  authenticate: () => Promise<boolean>;
+};
+
 export function LoginForm({
   className,
   control,
   authenticate,
-}: {
-  className?: string;
-  control: Control<LoginFormData>;
-  authenticate: () => Promise<boolean>;
-}) {
+}: LoginFormProps) {
   const {
-    hrefs: { signup, resetPassword },
+    hrefs: { signup, forgotPassword },
   } = useAuthPageSetup();
 
   const {
@@ -62,7 +64,7 @@ export function LoginForm({
             <Fcheckbox control={rememberMe} /> <label>Remember me</label>
           </div>
           <div>
-            <a href={resetPassword} className={linkStyle}>
+            <a href={forgotPassword} className={linkStyle}>
               Forgot your password?
             </a>
           </div>

--- a/astrolabe-ui/src/user/MfaForm.tsx
+++ b/astrolabe-ui/src/user/MfaForm.tsx
@@ -11,17 +11,19 @@ import { Button } from "../Button";
 import { Textfield } from "../Textfield";
 import React from "react";
 
+type MfaFormProps = {
+  className?: string;
+  control: Control<MfaFormData>;
+  authenticate: () => Promise<boolean>;
+  send: () => Promise<boolean>;
+};
+
 export function MfaForm({
   className,
   control,
   authenticate,
   send,
-}: {
-  className?: string;
-  control: Control<MfaFormData>;
-  authenticate: () => Promise<boolean>;
-  send: () => Promise<boolean>;
-}) {
+}: MfaFormProps) {
   const {
     fields: { code, token, updateNumber, number },
     error,

--- a/astrolabe-ui/src/user/ResetPasswordForm.tsx
+++ b/astrolabe-ui/src/user/ResetPasswordForm.tsx
@@ -1,62 +1,199 @@
-import { Control, useControl } from "@react-typed-forms/core";
+import {
+  Control,
+  useComputed,
+  useControl,
+  useControlEffect,
+} from "@react-typed-forms/core";
 import { Textfield } from "../Textfield";
 import { Button } from "../Button";
-import { ResetPasswordFormData } from "@astroapps/client";
+import {
+  MfaFormData,
+  ResetPasswordFormData,
+  useAuthPageSetup,
+} from "@astroapps/client";
 import { CircularProgress } from "../CircularProgress";
 import { UserFormContainer } from "./UserFormContainer";
+import React from "react";
+
+type ResetPasswordFormProps = {
+  className?: string;
+  control: Control<ResetPasswordFormData>;
+  resetPassword: () => Promise<boolean>;
+  send?: () => Promise<boolean>;
+  mfaControl?: Control<MfaFormData>;
+  mfaAuthenticate?: () => Promise<boolean>;
+};
 
 export function ResetPasswordForm({
   className,
   control,
   resetPassword,
-}: {
-  className?: string;
-  control: Control<ResetPasswordFormData>;
-  resetPassword: () => Promise<boolean>;
-}) {
+  send,
+  mfaControl,
+  mfaAuthenticate,
+}: ResetPasswordFormProps) {
   const {
-    fields: { email },
+    fields: { password, confirm },
     disabled,
+    error,
   } = control;
-  const hasBeenReset = useControl(false);
+
+  const passwordReset = useControl(false);
+
+  const codeSent = useControl(false);
+  const codeValid = useControl(false);
+  const {
+    errors: { codeLimit },
+  } = useAuthPageSetup();
+
+  useControlEffect(
+    () => mfaControl?.fields.code.value,
+    () => {
+      if (control.error != codeLimit) control.error = null;
+    },
+  );
+
+  const mfaNumber = useComputed(() => {
+    const tokenPayload = mfaControl?.value
+      ? JSON.parse(atob(mfaControl.value.token.split(".")[1]))
+      : null;
+    if (tokenPayload?.mn) {
+      return tokenPayload.mn as string;
+    }
+    return null;
+  });
+
+  const contactNumber = useComputed(() => {
+    const tokenPayload = mfaControl?.value
+      ? JSON.parse(atob(mfaControl.value.token.split(".")[1]))
+      : null;
+    if (tokenPayload?.cn) {
+      return tokenPayload.cn as string;
+    }
+    return null;
+  });
+
+  useControlEffect(
+    () => contactNumber.value,
+    (v) => {
+      if (v) {
+        mfaControl!.fields.number.value = v;
+      }
+    },
+    true,
+  );
+
   return (
     <UserFormContainer className={className}>
-      {hasBeenReset.value ? (
+      {passwordReset.value ? (
         <>
-          <h2>Check email to continue</h2>
+          <h2>You password has been changed.</h2>
           <p className="font-light text-gray-500 dark:text-gray-400">
-            You will receive an email with further instructions on how to reset
-            your password
+            You may now login with your new password
           </p>
         </>
       ) : (
         <>
-          <h2>Forgot your password?</h2>
-          <p className="font-light text-gray-500 dark:text-gray-400">
-            Don't fret! Just type in your email and we will send you a code to
-            reset your password!
-          </p>
+          <h2>Change your password</h2>
           <form
             className="space-y-4 md:space-y-6"
             onSubmit={(e) => {
               e.preventDefault();
-              doReset();
+              doChange();
             }}
           >
-            <Textfield control={email} label="Email" autoComplete="username" />
-            {disabled && <CircularProgress />}
-            <Button className="w-full" type="submit" disabled={disabled}>
-              Reset Password
-            </Button>
+            {!codeSent.value || !codeValid.value ? (
+              <>
+                {!codeSent.value ? (
+                  <>
+                    <p>
+                      We have the following mobile number XXXX XXX{" "}
+                      {mfaNumber.value?.slice(-3) ??
+                        contactNumber.value?.slice(-3)}
+                    </p>
+                    <Button
+                      type="button"
+                      onClick={async () => {
+                        if (send && (await send())) codeSent.value = true;
+                      }}
+                    >
+                      Send Verification Code
+                    </Button>
+                  </>
+                ) : (
+                  <div className="flex flex-col gap-3">
+                    <div>
+                      <p>
+                        We sent a code to XXXX XXX{" "}
+                        {mfaNumber.value?.slice(-3) ??
+                          contactNumber.value?.slice(-3)}
+                      </p>
+                      <Textfield
+                        control={mfaControl!.fields.code}
+                        label="Code"
+                      />
+                    </div>
+                    <Button
+                      type="button"
+                      onClick={async () =>
+                        (codeValid.value = await mfaAuthenticate!())
+                      }
+                      disabled={
+                        !mfaControl!.fields.code.value ||
+                        mfaControl!.fields.code.value.length != 6 ||
+                        control.error === codeLimit
+                      }
+                    >
+                      Verify code
+                    </Button>
+                    <p>
+                      Haven't got an SMS from us?{" "}
+                      <button
+                        className="underline"
+                        onClick={send}
+                        disabled={control.error === codeLimit}
+                        type="button"
+                      >
+                        Resend the code
+                      </button>
+                    </p>
+                  </div>
+                )}
+              </>
+            ) : (
+              <ChangePassword />
+            )}
+            {error && <p className="text-danger">{error}</p>}
           </form>
         </>
       )}
     </UserFormContainer>
   );
-  async function doReset() {
-    control.disabled = true;
-    const wasReset = await resetPassword();
-    hasBeenReset.value = wasReset;
-    if (!wasReset) control.disabled = false;
+
+  function ChangePassword() {
+    return (
+      <>
+        <Textfield
+          control={password}
+          label="New Password"
+          type="password"
+          autoComplete="new-password"
+        />
+        <Textfield
+          control={confirm}
+          label="Confirm Password"
+          type="password"
+          autoComplete="new-password"
+        />
+        {disabled && <CircularProgress />}
+        <Button className="w-full" type="submit" disabled={disabled}>
+          Change password
+        </Button>
+      </>
+    );
+  }
+
+  async function doChange() {
+    passwordReset.value = await resetPassword();
   }
 }

--- a/astrolabe-ui/src/user/SignupForm.tsx
+++ b/astrolabe-ui/src/user/SignupForm.tsx
@@ -6,17 +6,19 @@ import { CircularProgress } from "../CircularProgress";
 import { ReactNode } from "react";
 import { UserFormContainer } from "./UserFormContainer";
 
+type SignupFormProps = {
+  className?: string;
+  control: Control<SignupFormData>;
+  createAccount: () => Promise<boolean>;
+  children?: ReactNode;
+};
+
 export function SignupForm({
   className,
   control,
   createAccount,
   children,
-}: {
-  className?: string;
-  control: Control<SignupFormData>;
-  createAccount: () => Promise<boolean>;
-  children?: ReactNode;
-}) {
+}: SignupFormProps) {
   const {
     fields: { password, confirm, email },
     disabled,

--- a/astrolabe-ui/src/user/UserFormContainer.tsx
+++ b/astrolabe-ui/src/user/UserFormContainer.tsx
@@ -1,13 +1,14 @@
 import clsx from "clsx";
 import { ReactNode } from "react";
 
+type UserFormContainerProps = {
+  className?: string;
+  children: ReactNode;
+};
 export function UserFormContainer({
   className,
   children,
-}: {
-  className?: string;
-  children: ReactNode;
-}) {
+}: UserFormContainerProps) {
   return (
     <div className={clsx("p-6 space-y-4 md:space-y-6 sm:p-8", className)}>
       {children}

--- a/astrolabe-ui/src/user/VerifyForm.tsx
+++ b/astrolabe-ui/src/user/VerifyForm.tsx
@@ -11,17 +11,19 @@ import { Textfield } from "../Textfield";
 import { Button } from "../Button";
 import React from "react";
 
+type VerifyFormProps = {
+  className?: string;
+  control: Control<VerifyFormData>;
+  authenticate: () => Promise<boolean>;
+  send: () => Promise<boolean>;
+};
+
 export function VerifyForm({
   className,
   control,
   authenticate,
   send,
-}: {
-  className?: string;
-  control: Control<VerifyFormData>;
-  authenticate: () => Promise<boolean>;
-  send: () => Promise<boolean>;
-}) {
+}: VerifyFormProps) {
   const {
     fields: { code, token, number, updateNumber },
     error,


### PR DESCRIPTION
# astrolabe-client changes
- Added `/forgotPassword` route in place of `/resetPassword`
- Split `/changePassword` into `/resetPassword` (unauthenticated) and `/changePassword` (authenticated) routes
- Modified corresponding props for above
- Minor refactors and formatting

# astrolabe-ui changes
- Added `ForgotPasswordForm` in place of `ResetPasswordForm`
- Split `ChangePasswordForm` into `ResetPasswordForm` (unauthenticated) and `ChangePasswordForm` (authenticated)
- Minor refactors and formatting

# Astrolabe.LocalUsers changes
- Split the change password method into dedicated methods for change or reset flows
- Updated `README.md`
- Minor refactors and formatting