### PR TITLE
Feature/optional mfa misc

### DIFF
--- a/Astrolabe.LocalUsers/AbstractLocalUserController.cs
+++ b/Astrolabe.LocalUsers/AbstractLocalUserController.cs
@@ -57,6 +57,7 @@ public abstract class AbstractLocalUserController<TNewUser, TUserId> : Controlle
         return _localUserService.ForgotPassword(email);
     }
 
+    [Authorize]
     [HttpPost("changeEmail")]
     public Task ChangeEmail(ChangeEmail email)
     {
@@ -69,6 +70,7 @@ public abstract class AbstractLocalUserController<TNewUser, TUserId> : Controlle
         return _localUserService.ChangeMfaNumber(number, GetUserId);
     }
 
+    [Authorize]
     [HttpPost("mfaChangeMfaNumber")]
     public Task MfaChangeMfaNumber(MfaChangeNumber change)
     {

--- a/astrolabe-client/src/app/user.ts
+++ b/astrolabe-client/src/app/user.ts
@@ -407,7 +407,7 @@ export function useResetPasswordPage(
       : null,
   );
 
-  const authTokenControl = useControl<string>("");
+  const authTokenControl = useControl<string>(resetCode ?? "");
 
   return {
     control,

--- a/astrolabe-client/src/app/user.ts
+++ b/astrolabe-client/src/app/user.ts
@@ -473,6 +473,7 @@ export function useSignupPage<A extends SignupFormData = SignupFormData>(
 
 export interface VerifyFormData {
   token: string | null;
+  requiresMfa: boolean;
   code: string;
   updateNumber: boolean;
   number: string | null;
@@ -480,6 +481,7 @@ export interface VerifyFormData {
 
 const emptyVerifyFormData: VerifyFormData = {
   token: null,
+  requiresMfa: false,
   code: "",
   updateNumber: false,
   number: null,
@@ -492,7 +494,9 @@ interface VerifyProps {
 }
 
 export function useVerifyPage(
-  runVerify: (code: string) => Promise<any>,
+  runVerify: (
+    verificationCode: string,
+  ) => Promise<Partial<VerifyFormData> | undefined>,
   runAuthenticate: (data: VerifyFormData) => Promise<any>,
   send: (data: VerifyFormData) => Promise<any>,
   errors?: Record<number, string>,
@@ -532,7 +536,8 @@ export function useVerifyPage(
   async function doVerify() {
     if (verificationCode) {
       try {
-        control.fields.token.value = await runVerify(verificationCode);
+        const verifyResponse = await runVerify(verificationCode);
+        control.setValue((c) => ({ ...c, ...verifyResponse }));
       } catch (e) {
         makeStatusCodeHandler(
           control,

--- a/astrolabe-client/src/app/user.ts
+++ b/astrolabe-client/src/app/user.ts
@@ -1,4 +1,9 @@
-import { Control, notEmpty, useControl } from "@react-typed-forms/core";
+import {
+  Control,
+  notEmpty,
+  useComputed,
+  useControl,
+} from "@react-typed-forms/core";
 import {
   isApiResponse,
   makeStatusCodeHandler,
@@ -489,6 +494,7 @@ const emptyVerifyFormData: VerifyFormData = {
 
 interface VerifyProps {
   control: Control<VerifyFormData>;
+  mfaControl: Control<MfaFormData>;
   authenticate: () => Promise<boolean>;
   send: () => Promise<boolean>;
 }
@@ -497,8 +503,8 @@ export function useVerifyPage(
   runVerify: (
     verificationCode: string,
   ) => Promise<Partial<VerifyFormData> | undefined>,
-  runAuthenticate: (data: VerifyFormData) => Promise<any>,
-  send: (data: VerifyFormData) => Promise<any>,
+  runAuthenticate: (data: MfaFormData) => Promise<any>,
+  send: (data: MfaFormData) => Promise<any>,
   errors?: Record<number, string>,
 ): VerifyProps {
   const {
@@ -510,6 +516,17 @@ export function useVerifyPage(
   const verificationCode = searchParams.get(verifyCode);
 
   const control = useControl(emptyVerifyFormData);
+  const mfaControl = useComputed<MfaFormData>(() => {
+    return {
+      token:
+        control.value.requiresMfa && control.value.token
+          ? control.value.token
+          : "",
+      code: "",
+      updateNumber: false,
+      number: null,
+    };
+  });
 
   useEffect(() => {
     doVerify();
@@ -517,17 +534,18 @@ export function useVerifyPage(
 
   return {
     control: control,
+    mfaControl,
     authenticate: () =>
       validateAndRunMessages(
         control,
-        () => runAuthenticate(control.value),
+        () => runAuthenticate(mfaControl.value),
         { 401: wrongCode, 429: codeLimit, ...(errors ?? statusCodes) },
         generic,
       ),
     send: () =>
       validateAndRunMessages(
         control,
-        () => send(control.value),
+        () => send(mfaControl.value),
         { 429: codeLimit, ...(errors ?? statusCodes) },
         generic,
       ),

--- a/astrolabe-client/src/app/user.ts
+++ b/astrolabe-client/src/app/user.ts
@@ -479,17 +479,11 @@ export function useSignupPage<A extends SignupFormData = SignupFormData>(
 export interface VerifyFormData {
   token: string | null;
   requiresMfa: boolean;
-  code: string;
-  updateNumber: boolean;
-  number: string | null;
 }
 
 const emptyVerifyFormData: VerifyFormData = {
   token: null,
   requiresMfa: false,
-  code: "",
-  updateNumber: false,
-  number: null,
 };
 
 interface VerifyProps {

--- a/astrolabe-client/src/service/security.ts
+++ b/astrolabe-client/src/service/security.ts
@@ -1,7 +1,6 @@
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect } from "react";
 import { AppContext } from "./index";
 import { Control, newControl, useControl } from "@react-typed-forms/core";
-import { RouteData } from "../app/routeData";
 import { useNavigationService } from "./navigation";
 import { parseJwt } from "../util/jwt";
 
@@ -81,7 +80,11 @@ export function createAccessTokenFetcher(
   };
 }
 
-export function useControlTokenSecurity(): TokenSecurityService {
+export function useControlTokenSecurity(options?: {
+  getUserData?: (
+    fetch: SecurityService["fetch"],
+  ) => Promise<Partial<UserState>>;
+}): TokenSecurityService {
   const tokens = getTokenStorage();
   const user = useControl<UserState>({
     busy: true,
@@ -89,8 +92,7 @@ export function useControlTokenSecurity(): TokenSecurityService {
     loggedIn: false,
   });
   useEffect(() => {
-    const accessToken = tokens.getItem("token");
-    user.value = { busy: false, ...userStateFromToken(accessToken) };
+    checkInitial();
   }, []);
   return {
     currentUser: user,
@@ -103,13 +105,38 @@ export function useControlTokenSecurity(): TokenSecurityService {
     },
     async login() {},
     async setToken(accessToken: string) {
-      tokens.setItem("token", accessToken);
-      user.setValue((v) => ({
-        ...v,
-        ...userStateFromToken(accessToken),
-      }));
+      await setupUserFromToken(accessToken);
     },
   };
+
+  async function checkInitial() {
+    const accessToken = tokens.getItem("token");
+    const userData =
+      accessToken && options?.getUserData
+        ? await options.getUserData(
+            createAccessTokenFetcher(async () => accessToken),
+          )
+        : undefined;
+
+    user.value = {
+      ...userStateFromToken(accessToken),
+      ...userData,
+      busy: false,
+    };
+  }
+
+  async function setupUserFromToken(accessToken: string) {
+    tokens.setItem("token", accessToken);
+    const userData = {
+      ...userStateFromToken(accessToken),
+      ...(options?.getUserData
+        ? await options.getUserData(
+            createAccessTokenFetcher(async () => accessToken),
+          )
+        : undefined),
+    };
+    user.setValue((cu) => ({ ...cu, ...userData }));
+  }
 }
 
 export function userStateFromToken(jwtToken: string | null): {

--- a/astrolabe-client/src/service/security.ts
+++ b/astrolabe-client/src/service/security.ts
@@ -80,11 +80,14 @@ export function createAccessTokenFetcher(
   };
 }
 
-export function useControlTokenSecurity(options?: {
+export type ControlTokenSecurityOptions = {
   getUserData?: (
     fetch: SecurityService["fetch"],
   ) => Promise<Partial<UserState>>;
-}): TokenSecurityService {
+};
+export function useControlTokenSecurity(
+  options?: ControlTokenSecurityOptions,
+): TokenSecurityService {
   const tokens = getTokenStorage();
   const user = useControl<UserState>({
     busy: true,

--- a/astrolabe-ui/src/user/ChangePasswordForm.tsx
+++ b/astrolabe-ui/src/user/ChangePasswordForm.tsx
@@ -42,14 +42,14 @@ export function ChangePasswordForm({
               doChange();
             }}
           >
-            <ChangePassword />
+            {changePasswordForm()}
           </form>
         </>
       )}
     </UserFormContainer>
   );
 
-  function ChangePassword() {
+  function changePasswordForm() {
     return (
       <>
         <Textfield

--- a/astrolabe-ui/src/user/ForgotPasswordForm.tsx
+++ b/astrolabe-ui/src/user/ForgotPasswordForm.tsx
@@ -1,7 +1,11 @@
 import { Control, useControl } from "@react-typed-forms/core";
 import { Textfield } from "../Textfield";
 import { Button } from "../Button";
-import { ForgotPasswordFormData } from "@astroapps/client";
+import {
+  ForgotPasswordFormData,
+  useAuthPageSetup,
+  useNavigationService,
+} from "@astroapps/client";
 import { CircularProgress } from "../CircularProgress";
 import { UserFormContainer } from "./UserFormContainer";
 
@@ -16,10 +20,14 @@ export function ForgotPasswordForm({
   control,
   requestResetPassword,
 }: ForgotPasswordFormProps) {
+  const { Link } = useNavigationService();
   const {
     fields: { email },
     disabled,
   } = control;
+  const {
+    hrefs: { login },
+  } = useAuthPageSetup();
   const resetRequested = useControl(false);
 
   return (
@@ -54,6 +62,14 @@ export function ForgotPasswordForm({
           </form>
         </>
       )}
+      <p className="text-center">
+        <Link
+          href={login}
+          className="text-sm font-medium text-primary-600 hover:underline dark:text-primary-500"
+        >
+          Back to Login
+        </Link>
+      </p>
     </UserFormContainer>
   );
 

--- a/astrolabe-ui/src/user/LoginForm.tsx
+++ b/astrolabe-ui/src/user/LoginForm.tsx
@@ -2,7 +2,11 @@ import { Textfield } from "../Textfield";
 import { Control, Fcheckbox, useControlEffect } from "@react-typed-forms/core";
 import { Button } from "../Button";
 import clsx from "clsx";
-import { LoginFormData, useAuthPageSetup } from "@astroapps/client";
+import {
+  LoginFormData,
+  useAuthPageSetup,
+  useNavigationService,
+} from "@astroapps/client";
 import { CircularProgress } from "../CircularProgress";
 import { UserFormContainer } from "./UserFormContainer";
 
@@ -17,6 +21,7 @@ export function LoginForm({
   control,
   authenticate,
 }: LoginFormProps) {
+  const { Link } = useNavigationService();
   const {
     hrefs: { signup, forgotPassword },
   } = useAuthPageSetup();
@@ -44,9 +49,9 @@ export function LoginForm({
       >
         <div className="flex">
           <div>Do you have an account yet?</div>
-          <a className={clsx("ml-1 ", linkStyle)} href={signup}>
+          <Link className={clsx("ml-1", linkStyle)} href={signup}>
             Signup
-          </a>
+          </Link>
         </div>
         <Textfield
           control={username}
@@ -61,12 +66,13 @@ export function LoginForm({
         />
         <div className="flex justify-between text-sm">
           <div>
-            <Fcheckbox control={rememberMe} /> <label>Remember me</label>
+            <Fcheckbox id="rememberMe" control={rememberMe} />{" "}
+            <label htmlFor="rememberMe">Remember me</label>
           </div>
           <div>
-            <a href={forgotPassword} className={linkStyle}>
+            <Link href={forgotPassword} className={linkStyle}>
               Forgot your password?
-            </a>
+            </Link>
           </div>
         </div>
         {error && <p className="text-danger">{error}</p>}

--- a/astrolabe-ui/src/user/MfaForm.tsx
+++ b/astrolabe-ui/src/user/MfaForm.tsx
@@ -1,15 +1,8 @@
-import {
-  Control,
-  Fcheckbox,
-  useComputed,
-  useControl,
-  useControlEffect,
-} from "@react-typed-forms/core";
-import { MfaFormData, useAuthPageSetup } from "@astroapps/client";
+import { Control } from "@react-typed-forms/core";
+import { MfaFormData } from "@astroapps/client";
 import { UserFormContainer } from "./UserFormContainer";
-import { Button } from "../Button";
-import { Textfield } from "../Textfield";
 import React from "react";
+import SmsMfa from "./SmsMfa";
 
 type MfaFormProps = {
   className?: string;
@@ -24,51 +17,6 @@ export function MfaForm({
   authenticate,
   send,
 }: MfaFormProps) {
-  const {
-    fields: { code, token, updateNumber, number },
-    error,
-  } = control;
-  const {
-    errors: { codeLimit },
-  } = useAuthPageSetup();
-
-  const mfaNumber = useComputed(() => {
-    const tokenPayload = JSON.parse(atob(token.value.split(".")[1]));
-    if (tokenPayload.mn) {
-      return tokenPayload.mn as string;
-    }
-    return null;
-  });
-
-  const contactNumber = useComputed(() => {
-    const tokenPayload = JSON.parse(atob(token.value.split(".")[1]));
-    if (tokenPayload.cn) {
-      return tokenPayload.cn as string;
-    }
-    return null;
-  });
-
-  useControlEffect(
-    () => updateNumber.value,
-    (v) => {
-      if (!v && contactNumber.value) {
-        number.value = contactNumber.value;
-      } else {
-        number.value = null;
-      }
-    },
-    true,
-  );
-
-  const codeSent = useControl(false);
-
-  useControlEffect(
-    () => code.value,
-    () => {
-      if (control.error != codeLimit) control.error = null;
-    },
-  );
-
   return (
     <UserFormContainer className={className}>
       <h2>Login</h2>
@@ -78,75 +26,8 @@ export function MfaForm({
           e.preventDefault();
         }}
       >
-        {codeSent.value ? (
-          <div className="flex flex-col gap-3">
-            <div>
-              <p>
-                We sent a code to XXXX XXX{" "}
-                {mfaNumber.value?.slice(-3) ?? number.value?.slice(-3)}
-              </p>
-              <Textfield control={code} label="Code" />
-              {error && <p className="text-danger">{error}</p>}
-            </div>
-            <Button
-              onClick={authenticate}
-              disabled={
-                !code.value ||
-                code.value.length != 6 ||
-                control.error === codeLimit
-              }
-            >
-              Verify code
-            </Button>
-            <p>
-              Haven't got an SMS from us?{" "}
-              <button
-                className="underline"
-                onClick={sendCode}
-                disabled={control.error === codeLimit}
-              >
-                Resend the code
-              </button>
-            </p>
-          </div>
-        ) : (
-          <>
-            <p>
-              We have the following mobile number XXXX XXX{" "}
-              {mfaNumber.value?.slice(-3) ?? contactNumber.value?.slice(-3)}
-            </p>
-            {contactNumber.value && (
-              <div>
-                <div className="flex flex-row gap-2 items-center">
-                  <Fcheckbox id="updateNumber" control={updateNumber} />
-                  <label htmlFor="updateNumber">
-                    Send to a different number
-                  </label>
-                </div>
-              </div>
-            )}
-            {updateNumber.value && (
-              <>
-                <Textfield
-                  control={number}
-                  label={"Mobile Number"}
-                  readOnly={codeSent.value}
-                />
-              </>
-            )}
-            {error && <p className="text-danger">{error}</p>}
-            <Button onClick={sendCode}>Send Verification Code</Button>
-          </>
-        )}
+        <SmsMfa control={control} sendCode={send} verifyCode={authenticate} />
       </form>
     </UserFormContainer>
   );
-
-  async function sendCode() {
-    if (await send()) codeSent.value = true;
-    // await send();
-    // code.touched = false;
-    // if (!codeSent.value)
-    //   codeSent.value = true;
-  }
 }

--- a/astrolabe-ui/src/user/MfaForm.tsx
+++ b/astrolabe-ui/src/user/MfaForm.tsx
@@ -118,8 +118,10 @@ export function MfaForm({
             {contactNumber.value && (
               <div>
                 <div className="flex flex-row gap-2 items-center">
-                  <Fcheckbox control={updateNumber}></Fcheckbox>
-                  <label>Send to a different number</label>
+                  <Fcheckbox id="updateNumber" control={updateNumber} />
+                  <label htmlFor="updateNumber">
+                    Send to a different number
+                  </label>
                 </div>
               </div>
             )}

--- a/astrolabe-ui/src/user/ResetPasswordForm.tsx
+++ b/astrolabe-ui/src/user/ResetPasswordForm.tsx
@@ -106,11 +106,9 @@ export function ResetPasswordForm({
           >
             {
               // Requires MFA
-              contactNumber.value && (!codeSent.value || !codeValid.value) ? (
-                <MfaForm />
-              ) : (
-                <ChangePassword />
-              )
+              contactNumber.value && (!codeSent.value || !codeValid.value)
+                ? mfaForm()
+                : changePasswordForm()
             }
             {error && <p className="text-danger">{error}</p>}
           </form>
@@ -119,7 +117,7 @@ export function ResetPasswordForm({
     </UserFormContainer>
   );
 
-  function MfaForm() {
+  function mfaForm() {
     return (
       <>
         {!codeSent.value ? (
@@ -171,7 +169,7 @@ export function ResetPasswordForm({
     );
   }
 
-  function ChangePassword() {
+  function changePasswordForm() {
     return (
       <>
         <Textfield

--- a/astrolabe-ui/src/user/SignupForm.tsx
+++ b/astrolabe-ui/src/user/SignupForm.tsx
@@ -1,7 +1,11 @@
 import { Control, useControl } from "@react-typed-forms/core";
 import { Textfield } from "../Textfield";
 import { Button } from "../Button";
-import { SignupFormData, useAuthPageSetup } from "@astroapps/client";
+import {
+  SignupFormData,
+  useAuthPageSetup,
+  useNavigationService,
+} from "@astroapps/client";
 import { CircularProgress } from "../CircularProgress";
 import { ReactNode } from "react";
 import { UserFormContainer } from "./UserFormContainer";
@@ -19,6 +23,7 @@ export function SignupForm({
   createAccount,
   children,
 }: SignupFormProps) {
+  const { Link } = useNavigationService();
   const {
     fields: { password, confirm, email },
     disabled,
@@ -66,12 +71,12 @@ export function SignupForm({
             </Button>
             <p className="text-sm font-light text-gray-500 dark:text-gray-400">
               Already have an account?{" "}
-              <a
+              <Link
                 href={login}
                 className="font-medium text-primary-600 hover:underline dark:text-primary-500"
               >
                 Login here
-              </a>
+              </Link>
             </p>
           </form>
         </>

--- a/astrolabe-ui/src/user/SmsMfa.tsx
+++ b/astrolabe-ui/src/user/SmsMfa.tsx
@@ -1,0 +1,135 @@
+import { Button } from "../Button";
+import { Textfield } from "../Textfield";
+import React from "react";
+import {
+	Control,
+	Fcheckbox,
+	useComputed,
+	useControl,
+	useControlEffect,
+} from "@react-typed-forms/core";
+import { MfaFormData, useAuthPageSetup } from "@astroapps/client";
+
+type SmsMfaProps = {
+	control: Control<MfaFormData>;
+	sendCode: () => Promise<any>;
+	verifyCode: () => Promise<any>;
+};
+
+export default function SmsMfa({ control, sendCode, verifyCode }: SmsMfaProps) {
+	const {
+		errors: { codeLimit },
+	} = useAuthPageSetup();
+
+	const {
+		fields: { code, token, updateNumber, number },
+		error,
+	} = control;
+
+	// Mobile number
+	const mobileNumber = useComputed(() => {
+		const tokenPayload = JSON.parse(atob(token.value.split(".")[1]));
+		if (tokenPayload.mn) {
+			return tokenPayload.mn as string;
+		}
+		return null;
+	});
+
+	// Backup number in some instances...
+	const contactNumber = useComputed(() => {
+		const tokenPayload = JSON.parse(atob(token.value.split(".")[1]));
+		if (tokenPayload.cn) {
+			return tokenPayload.cn as string;
+		}
+		return null;
+	});
+
+	useControlEffect(
+		() => updateNumber.value,
+		(v) => {
+			if (!v) {
+				number.value = null;
+				number.error = null;
+			}
+		},
+	);
+
+	useControlEffect(
+		() => code.value,
+		() => {
+			if (control.error != codeLimit) control.error = null;
+		},
+	);
+	const codeSent = useControl(false);
+
+	return (
+		<>
+			{codeSent.value ? (
+				<div className="flex flex-col gap-3">
+					<div>
+						<p>
+							We sent a code to XXXX XXX{" "}
+							{mobileNumber.value?.slice(-3) ?? number.value?.slice(-3)}
+						</p>
+						<Textfield control={code} label="Code" />
+						{error && <p className="text-danger">{error}</p>}
+					</div>
+					<Button
+						type="button"
+						onClick={verifyCode}
+						disabled={
+							!code.value ||
+							code.value.length != 6 ||
+							control.error === codeLimit
+						}
+					>
+						Verify code
+					</Button>
+					<p>
+						Haven't got an SMS from us?{" "}
+						<button
+							className="underline"
+							onClick={sendCode}
+							disabled={control.error === codeLimit}
+						>
+							Resend the code
+						</button>
+					</p>
+				</div>
+			) : (
+				<>
+					<p>
+						We have the following mobile number XXXX XXX{" "}
+						{mobileNumber.value?.slice(-3) ?? contactNumber.value?.slice(-3)}
+					</p>
+					{contactNumber.value && (
+						<div>
+							<div className="flex flex-row gap-2 items-center">
+								<Fcheckbox id="updateNumber" control={updateNumber} />
+								<label htmlFor="updateNumber">Send to a different number</label>
+							</div>
+						</div>
+					)}
+					{updateNumber.value && (
+						<>
+							<Textfield
+								control={number}
+								label={"Mobile Number"}
+								readOnly={codeSent.value}
+							/>
+						</>
+					)}
+					{error && <p className="text-danger">{error}</p>}
+					<Button
+						type="button"
+						onClick={async () => {
+							if (await sendCode()) codeSent.value = true;
+						}}
+					>
+						Send Code
+					</Button>
+				</>
+			)}
+		</>
+	);
+}

--- a/astrolabe-ui/src/user/VerifyForm.tsx
+++ b/astrolabe-ui/src/user/VerifyForm.tsx
@@ -10,6 +10,7 @@ import { UserFormContainer } from "./UserFormContainer";
 import { Textfield } from "../Textfield";
 import { Button } from "../Button";
 import React from "react";
+import { CircularProgress } from "../CircularProgress";
 
 type VerifyFormProps = {
   className?: string;
@@ -25,7 +26,7 @@ export function VerifyForm({
   send,
 }: VerifyFormProps) {
   const {
-    fields: { code, token, number, updateNumber },
+    fields: { code, token, number, updateNumber, requiresMfa },
     error,
   } = control;
   const {
@@ -72,7 +73,7 @@ export function VerifyForm({
 
       {error != verify ? (
         <>
-          {token.value && (
+          {requiresMfa.value ? (
             <>
               {!codeSent.value ? (
                 <div>
@@ -83,8 +84,10 @@ export function VerifyForm({
                           -3,
                         )}`}</p>
                         <div className="flex flex-row gap-2 items-center">
-                          <Fcheckbox control={updateNumber}></Fcheckbox>
-                          <label>Send to a different number</label>
+                          <Fcheckbox id="updateNumber" control={updateNumber} />
+                          <label htmlFor="updateNumber">
+                            Send to a different number
+                          </label>
                         </div>
                       </>
                     )}
@@ -137,6 +140,8 @@ export function VerifyForm({
               )}
               {error && <p className="text-danger">{error}</p>}
             </>
+          ) : (
+            <CircularProgress />
           )}
         </>
       ) : (
@@ -144,10 +149,4 @@ export function VerifyForm({
       )}
     </UserFormContainer>
   );
-
-  async function sendCode() {
-    await send();
-    code.touched = false;
-    if (!codeSent.value) codeSent.value = true;
-  }
 }

--- a/astrolabe-ui/src/user/VerifyForm.tsx
+++ b/astrolabe-ui/src/user/VerifyForm.tsx
@@ -1,20 +1,14 @@
-import {
-  Control,
-  Fcheckbox,
-  useComputed,
-  useControl,
-  useControlEffect,
-} from "@react-typed-forms/core";
-import { useAuthPageSetup, VerifyFormData } from "@astroapps/client";
+import { Control } from "@react-typed-forms/core";
+import { MfaFormData, VerifyFormData } from "@astroapps/client";
 import { UserFormContainer } from "./UserFormContainer";
-import { Textfield } from "../Textfield";
-import { Button } from "../Button";
 import React from "react";
 import { CircularProgress } from "../CircularProgress";
+import SmsMfa from "./SmsMfa";
 
 type VerifyFormProps = {
   className?: string;
   control: Control<VerifyFormData>;
+  mfaControl: Control<MfaFormData>;
   authenticate: () => Promise<boolean>;
   send: () => Promise<boolean>;
 };
@@ -22,124 +16,26 @@ type VerifyFormProps = {
 export function VerifyForm({
   className,
   control,
+  mfaControl,
   authenticate,
   send,
 }: VerifyFormProps) {
   const {
-    fields: { code, token, number, updateNumber, requiresMfa },
+    fields: { requiresMfa },
     error,
   } = control;
-  const {
-    errors: { codeLimit, verify },
-  } = useAuthPageSetup();
-
-  const contactNumber = useComputed(() => {
-    if (token.value) {
-      const tokenPayload = JSON.parse(atob(token.value.split(".")[1]));
-      if (tokenPayload.cn) return tokenPayload.cn as string;
-    }
-    return null;
-  });
-
-  const codeSent = useControl(false);
-
-  useControlEffect(
-    () => code.value,
-    () => {
-      if (control.error != codeLimit) control.error = null;
-    },
-  );
-
-  useControlEffect(
-    () => contactNumber.value,
-    (v) => {
-      if (!v) updateNumber.value = true;
-    },
-  );
-
-  useControlEffect(
-    () => updateNumber.value,
-    (v) => {
-      if (!v) {
-        number.value = null;
-        number.error = null;
-      }
-    },
-  );
 
   return (
     <UserFormContainer className={className}>
       <h2>Verifying</h2>
-
-      {error != verify ? (
+      {error == null ? (
         <>
           {requiresMfa.value ? (
-            <>
-              {!codeSent.value ? (
-                <div>
-                  <div className="flex flex-col gap-2">
-                    {contactNumber.value && (
-                      <>
-                        <p>{`Send code to XXXX XXX ${contactNumber.value.slice(
-                          -3,
-                        )}`}</p>
-                        <div className="flex flex-row gap-2 items-center">
-                          <Fcheckbox id="updateNumber" control={updateNumber} />
-                          <label htmlFor="updateNumber">
-                            Send to a different number
-                          </label>
-                        </div>
-                      </>
-                    )}
-                    {updateNumber.value && (
-                      <>
-                        <Textfield
-                          control={number}
-                          label={"Mobile Number"}
-                          readOnly={codeSent.value}
-                        />
-                      </>
-                    )}
-                    <Button
-                      onClick={async () => {
-                        if (await send()) codeSent.value = true;
-                      }}
-                    >
-                      Send Code
-                    </Button>
-                  </div>
-                </div>
-              ) : (
-                <>
-                  <p>
-                    We sent a code to XXXX XXX{" "}
-                    {number.value?.slice(-3) ?? contactNumber.value?.slice(-3)}
-                  </p>
-                  <Textfield control={code} label={"Code"} />
-                  <Button
-                    onClick={authenticate}
-                    disabled={
-                      !code.value ||
-                      code.value.length != 6 ||
-                      control.error === codeLimit
-                    }
-                  >
-                    Verify code
-                  </Button>
-                  <p>
-                    Haven't got an SMS from us?{" "}
-                    <button
-                      className="underline"
-                      onClick={send}
-                      disabled={control.error === codeLimit}
-                    >
-                      Resend the code
-                    </button>
-                  </p>
-                </>
-              )}
-              {error && <p className="text-danger">{error}</p>}
-            </>
+            <SmsMfa
+              control={mfaControl}
+              sendCode={send}
+              verifyCode={authenticate}
+            />
           ) : (
             <CircularProgress />
           )}


### PR DESCRIPTION
# astrolabe-client changes
- Added optional `getUserDetails` callback to `useControlTokenSecurity` to get optional extra details from endpoint after token setup
- Added `requiresMfa` flag to `VerifyFormData` and changed return type of `runVerify` to allow setting data other than just the token

# astrolabe-ui changes
- Added `SmsMfa` component and refactored usage in `MfaForm`, `ResetPasswordForm`, and `VerifyForm`
- Changed forms to work without mfa

# Astrolabe.LocalUsers changes
- Add `[Authorize]` annotation to endpoints for `changeEmail` and `mfaChangeMfaNumber`