### PR TITLE
Add Claude Code plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "astrolabe",
+  "owner": {
+    "name": "Astrolabe Apps",
+    "email": "jolse@astrolabeenterprises.com.au"
+  },
+  "metadata": {
+    "description": "Claude Code marketplace for the Astrolabe framework. Skills are maintained alongside the library code in this repo."
+  },
+  "plugins": [
+    {
+      "name": "astrolabe",
+      "description": "Skills for consuming the Astrolabe .NET and TypeScript/React libraries (schemas, workflow, file storage, local users, search, @react-typed-forms/*, @astroapps/*).",
+      "source": "./"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "astrolabe",
+  "description": "Skills for consuming the Astrolabe framework: .NET libraries (schemas, workflow, file storage, local users, search) and TypeScript/React packages (@react-typed-forms/*, @astroapps/*). Skills load on demand when Claude detects relevant work.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Astrolabe Apps"
+  },
+  "homepage": "https://github.com/astrolabe-apps/astrolabe-common",
+  "repository": "https://github.com/astrolabe-apps/astrolabe-common",
+  "license": "MIT"
+}


### PR DESCRIPTION
## What

Turns this repo into its own **Claude Code plugin marketplace** by adding:

- `.claude-plugin/marketplace.json` — the marketplace catalog (one plugin, `astrolabe`)
- `.claude-plugin/plugin.json` — the plugin manifest (`source: "./"`, skills auto-discovered from the existing `skills/` directory)

## Why

The 16 skills already live in `skills/` and are maintained alongside the library code. This makes them **distributable and auto-updating** for consumers, with a single source of truth — no more hand-copying skills into `~/.claude/skills/` (which had already drifted out of date).

## How consumers use it

Ad-hoc:
```
/plugin marketplace add astrolabe-apps/astrolabe-common
/plugin install astrolabe@astrolabe
```

Or committed to an app repo's `.claude/settings.json` for automatic, team-wide install + background updates:
```json
{
  "extraKnownMarketplaces": {
    "astrolabe": {
      "source": { "source": "github", "repo": "astrolabe-apps/astrolabe-common" },
      "autoUpdate": true
    }
  },
  "enabledPlugins": [
    { "marketplace": "astrolabe", "plugin": "astrolabe" }
  ]
}
```

Bump `version` in `.claude-plugin/plugin.json` when skills change so consumers pick up updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)