### PR TITLE
Add opt-in strict integer handling for [JsonString] enums

### DIFF
--- a/Astrolabe.Common.sln
+++ b/Astrolabe.Common.sln
@@ -73,6 +73,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Astrolabe.Forms.EF", "Astro
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Astrolabe.FormItems", "Astrolabe.FormItems\Astrolabe.FormItems.csproj", "{EC02B79C-82A9-44E1-B664-19058C97ACA2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Astrolabe.JSON.Tests", "Astrolabe.JSON.Tests\Astrolabe.JSON.Tests.csproj", "{D4999D1D-CBA8-42B0-8D83-68BD7F2A25F3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -223,5 +225,9 @@ Global
 		{EC02B79C-82A9-44E1-B664-19058C97ACA2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EC02B79C-82A9-44E1-B664-19058C97ACA2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EC02B79C-82A9-44E1-B664-19058C97ACA2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4999D1D-CBA8-42B0-8D83-68BD7F2A25F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4999D1D-CBA8-42B0-8D83-68BD7F2A25F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4999D1D-CBA8-42B0-8D83-68BD7F2A25F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4999D1D-CBA8-42B0-8D83-68BD7F2A25F3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Astrolabe.JSON.Tests/Astrolabe.JSON.Tests.csproj
+++ b/Astrolabe.JSON.Tests/Astrolabe.JSON.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Astrolabe.JSON/Astrolabe.JSON.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/Astrolabe.JSON.Tests/StringAttributeConverterTest.cs
+++ b/Astrolabe.JSON.Tests/StringAttributeConverterTest.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using Astrolabe.Annotation;
+using Astrolabe.JSON.Extensions;
+using Xunit;
+
+namespace Astrolabe.JSON.Tests;
+
+[JsonString]
+public enum TestRole
+{
+    View,
+    Edit,
+    Admin
+}
+
+public record TestUser(TestRole Role);
+
+public class StringAttributeConverterTest
+{
+    private static JsonSerializerOptions Lenient() =>
+        new JsonSerializerOptions().AddStandardOptions();
+
+    private static JsonSerializerOptions Strict() =>
+        new JsonSerializerOptions().AddStandardOptions(allowIntegerEnumValues: false);
+
+    [Fact]
+    public void ValidStringDeserializes()
+    {
+        var user = JsonSerializer.Deserialize<TestUser>("""{"role":"Edit"}""", Strict());
+        Assert.Equal(new TestUser(TestRole.Edit), user);
+    }
+
+    [Fact]
+    public void UnknownStringThrowsRegardlessOfStrictness()
+    {
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<TestUser>("""{"role":"NotARole"}""", Lenient())
+        );
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<TestUser>("""{"role":"NotARole"}""", Strict())
+        );
+    }
+
+    [Fact]
+    public void NumericValueAllowedByDefault()
+    {
+        var user = JsonSerializer.Deserialize<TestUser>("""{"role":999}""", Lenient());
+        Assert.Equal((TestRole)999, user!.Role);
+    }
+
+    [Fact]
+    public void NumericValueThrowsWhenStrict()
+    {
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<TestUser>("""{"role":999}""", Strict())
+        );
+    }
+
+    [Fact]
+    public void NumericValueOfDefinedMemberAlsoThrowsWhenStrict()
+    {
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<TestUser>("""{"role":0}""", Strict())
+        );
+    }
+
+#if NET9_0_OR_GREATER
+    // .NET 9 rewrote JsonStringEnumConverter so allowIntegerValues: false also rejects
+    // digit-leading strings; on .NET 8 and earlier only JSON numbers are rejected.
+    [Fact]
+    public void NumericStringThrowsWhenStrict()
+    {
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<TestUser>("""{"role":"999"}""", Strict())
+        );
+    }
+#endif
+
+    [Fact]
+    public void SerializesAsMemberName()
+    {
+        Assert.Equal(
+            """{"role":"Admin"}""",
+            JsonSerializer.Serialize(new TestUser(TestRole.Admin), Strict())
+        );
+    }
+
+    [Fact]
+    public void SerializingUndefinedValueThrowsWhenStrict()
+    {
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Serialize(new TestUser((TestRole)999), Strict())
+        );
+    }
+}

--- a/Astrolabe.JSON/Astrolabe.JSON.csproj
+++ b/Astrolabe.JSON/Astrolabe.JSON.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.2.1</Version>
+        <Version>1.3.0</Version>
         <Description>JSON utilities for System.Text.Json</Description>
         <PackageTags>json adt</PackageTags>
     </PropertyGroup>

--- a/Astrolabe.JSON/Extensions/JsonSerializerOptionsExtensions.cs
+++ b/Astrolabe.JSON/Extensions/JsonSerializerOptionsExtensions.cs
@@ -5,12 +5,20 @@ namespace Astrolabe.JSON.Extensions;
 
 public static class JsonSerializerOptionsExtensions
 {
-    public static JsonSerializerOptions AddStandardOptions(this JsonSerializerOptions options)
+    /// <summary>
+    /// Applies the standard Astrolabe serializer settings. Pass
+    /// <paramref name="allowIntegerEnumValues"/> = false to make enums marked with
+    /// [JsonString] reject numeric values on deserialization.
+    /// </summary>
+    public static JsonSerializerOptions AddStandardOptions(
+        this JsonSerializerOptions options,
+        bool allowIntegerEnumValues = true
+    )
     {
         options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
         options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
         options.Converters.Add(new JsonBaseTypeConverter());
-        options.Converters.Add(new StringAttributeConverter());
+        options.Converters.Add(new StringAttributeConverter(allowIntegerEnumValues));
         return options;
     }
 }

--- a/Astrolabe.JSON/StringAttributeConverter.cs
+++ b/Astrolabe.JSON/StringAttributeConverter.cs
@@ -4,9 +4,20 @@ using Astrolabe.Annotation;
 
 namespace Astrolabe.JSON;
 
+/// <summary>
+/// Serializes enums marked with <see cref="JsonStringAttribute"/> as their member names.
+/// Pass <c>allowIntegerValues: false</c> to reject numeric JSON values (and numeric
+/// strings) on read, so an undefined member (e.g. 999) fails deserialization instead
+/// of materialising as an undefined enum value.
+/// </summary>
 public class StringAttributeConverter : JsonConverterFactory
 {
-    private readonly JsonStringEnumConverter _inner = new();
+    private readonly JsonStringEnumConverter _inner;
+
+    public StringAttributeConverter(bool allowIntegerValues = true)
+    {
+        _inner = new JsonStringEnumConverter(allowIntegerValues: allowIntegerValues);
+    }
 
     public override bool CanConvert(Type typeToConvert)
     {


### PR DESCRIPTION
## Add opt-in strict integer handling for `[JsonString]` enums

### Problem

Enums marked with `[JsonString]` accept undefined numeric values on deserialization:
`{"role": 999}` (and on newer runtimes `{"role": "999"}`) materialise as `(Role)999` — an
undefined-but-legal enum value — instead of failing. Unknown _names_ (`"NotARole"`) were
always rejected; the numeric paths were the hole. For consumers persisting these enums as
strings, that's silent data corruption at the API boundary.

Root cause: `StringAttributeConverter` delegates to `JsonStringEnumConverter` with its
default `allowIntegerValues: true`.

### Change

Strictness is **opt-in** — default behaviour is unchanged for all existing consumers:

```csharp
// Options level (new parameter, defaults to true):
options.AddStandardOptions(allowIntegerEnumValues: false);

// Converter level (mirrors JsonStringEnumConverter's parameter name):
new StringAttributeConverter(allowIntegerValues: false);
```

- `Astrolabe.JSON` bumped **1.2.1 → 1.3.0** (additive, non-breaking)
- New `Astrolabe.JSON.Tests` project added to the solution

### Behaviour

| Payload                            | Default (lenient)  | `allowIntegerEnumValues: false` (strict)           |
| ---------------------------------- | ------------------ | -------------------------------------------------- |
| `{"role": "Edit"}`                 | ✅ `Role.Edit`     | ✅ `Role.Edit`                                     |
| `{"role": "NotARole"}`             | ❌ `JsonException` | ❌ `JsonException`                                 |
| `{"role": 999}` (undefined)        | ⚠️ `(Role)999`     | ❌ `JsonException`                                 |
| `{"role": 0}` (defined member)     | ✅ `Role.View`     | ❌ `JsonException`                                 |
| `{"role": "999"}` (numeric string) | ⚠️ `(Role)999`     | ❌ on .NET 9+ · ⚠️ still accepted on .NET 8        |
| Serialize `Role.Admin`             | `"Admin"`          | `"Admin"`                                          |
| Serialize `(Role)999` (undefined)  | `999`              | ❌ `JsonException` (garbage fails loudly on write) |

### Runtime caveat

`JsonStringEnumConverter(allowIntegerValues: false)` only rejects digit-leading _strings_
from .NET 9 onwards (converter rewrite); .NET 8 rejects JSON numbers but still parses
`"999"`. The test for that case is guarded with `#if NET9_0_OR_GREATER` and is currently
compiled out, since `global.json` pins the SDK to 8.x — it activates automatically when
the repo moves to a newer SDK.

### Testing

- 7 tests passing in the new `Astrolabe.JSON.Tests` (net8.0), covering every row above
- Full solution builds with 0 errors

One honesty note baked into the table: I marked the "999" strict row as .NET-9-conditional rather than a plain ❌, since on .NET 8 it still parses — that matches what the tests actually proved.
